### PR TITLE
Translate LATS notebook to Korean

### DIFF
--- a/docs/docs/tutorials/lats/lats.ipynb
+++ b/docs/docs/tutorials/lats/lats.ipynb
@@ -10,18 +10,18 @@
    "id": "9e0c1743-8775-4de2-a599-78b050551489",
    "metadata": {},
    "source": [
-    "# Language Agent Tree Search\n",
+    "# 언어 에이전트 트리 탐산\n",
     "\n",
-    "[Language Agent Tree Search](https://arxiv.org/abs/2310.04406) (LATS), by Zhou, et. al, is a general LLM agent search algorithm that combines reflection/evaluation and search (specifically monte-carlo trees search) to get achieve better overall task performance compared to similar techniques like ReACT, Reflexion, or Tree of Thoughts.\n",
+    "[Language Agent Tree Search](https://arxiv.org/abs/2310.04406) (LATS)는 Zhou 등 저자의 노동으로, 반성/평가와 탐산(특히 모탐카를로 트리 탐산)을 결합하여 ReACT, Reflexion, Tree of Thoughts와 같은 기반등에서 더 나은 작업 성능을 얻는 일반적인 LLM 에이전트 탐산 알고리즘입니다.\n",
     "\n",
     "![LATS diagram](attachment:969d281d-0b01-4252-acc1-b98efa936324.png)\n",
     "\n",
-    "It has four main steps:\n",
+    "LATS는 네 단계로 이배됩니다.\n",
     "\n",
-    "1. Select: pick the best next actions based on the aggregate rewards from step (2). Either respond (if a solution is found or the max search depth is reached) or continue searching.\n",
-    "2. Expand and simulate: select the \"best\" 5 potential actions to take and execute them in parallel.\n",
-    "3. Reflect + Evaluate: observe the outcomes of these actions and score the decisions based on reflection (and possibly external feedback)\n",
-    "4. Backpropagate: update the scores of the root trajectories based on the outcomes."
+    "1. **선택**: 단계 (2)의 누주형 보상을 기반으로 다음 행동을 선택합니다. 풀러리션을 찾거나 최대 탐산 길이에 돌아가면 응답하고, 그렇지 않으면 계속 탐산합니다.\n",
+    "2. **확장 및 시뮬레이션**: 재형 가능한 개념 5개를 선택하여 버림니다.\n",
+    "3. **반성 및 평가**: 행동의 결과를 구경하고, 반성(및 그리고 가능한 외부 피드래치)에 기반하여 팔리를 확정합니다.\n",
+    "4. **역전파**: 결과를 기반으로 루트 경로의 점수를 업데이트합니다.\n"
    ]
   },
   {
@@ -29,11 +29,11 @@
    "id": "db28668b-5491-4c93-a961-bd339f09202c",
    "metadata": {},
    "source": [
-    "## Setup\n",
+    "## 설정\n",
     "\n",
-    "Install `langgraph` (for the framework), `langchain_openai` (for the LLM), and `langchain` + `tavily-python` (for the search engine).\n",
+    "프레임워크용 `langgraph`, LLM용 `langchain_openai`, 및 검색 에어진용 `langchain` 과 `tavily-python`을 설치합니다.\n",
     "\n",
-    "We will use tavily search as a tool. You can get an API key [here](https://app.tavily.com/sign-in) or replace with a different tool of your choosing."
+    "여기서는 Tavily 검색을 도구로 사용합니다. [여기](https://app.tavily.com/sign-in)에서 API 키를 받거나 다른 도구로 대체할 수 있습니다.\n"
    ]
   },
   {
@@ -75,11 +75,11 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition tip\">\n",
-    "    <p class=\"admonition-title\">Set up <a href=\"https://smith.langchain.com\">LangSmith</a> for LangGraph development</p>\n",
+    "    <p class=\"admonition-title\">LangGraph 개발을 위한 <a href=\"https://smith.langchain.com\">LangSmith</a>를 설정하세요</p>\n",
     "    <p style=\"padding-top: 5px;\">\n",
-    "        Sign up for LangSmith to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph — read more about how to get started <a href=\"https://docs.smith.langchain.com\">here</a>. \n",
+    "        LangSmith에 가입하면 LangGraph 프로젝트의 문제를 빠른 시간에 찾고 성능을 감소할 수 있습니다. LangSmith는 차치 데이터를 사용하여 디버그, 테스트, 모니터링을 수행할 수 있게 해 줍니다. <a href=\"https://docs.smith.langchain.com\">여기</a>에서 시작 방법을 더 자세히 보십시오.\n",
     "    </p>\n",
-    "</div>   "
+    "</div>\n"
    ]
   },
   {
@@ -92,15 +92,15 @@
    "id": "f857eacb-af4a-47d1-b45f-da74941125c2",
    "metadata": {},
    "source": [
-    "## Graph State\n",
+    "## 그래프 상태\n",
     "\n",
-    "LATS is based on a  (greedy) Monte-Carlo tree search. For each search steps, it picks the node with the highest \"upper confidence bound\", which is a metric that balances exploitation (highest average reward) and exploration (lowest visits). Starting from that node, it generates N (5 in this case) new candidate actions to take, and adds them to the tree. It stops searching either when it has generated a valid solution OR when it has reached the maximum number of rollouts (search tree depth).\n",
+    "LATS는 탐산적 모탐카를로 트리 탐산을 기반으로 합니다. 매 탐산 단계마다 '최상 실최 경계'가 높은 노들을 선택합니다. 이 값은 최고 평균 발생과 최소 방문수를 그룹하게 고려하는 지품입니다. 경간 노들에서 N(여기서는 5)개의 후부 행동을 생성하여 트리에 추가합니다. 유효한 해당을 찾거나 최대 로번타입에 돌아가면 탐산을 종료합니다.\n",
     "\n",
     "![Tree Diagram](attachment:9d9d2775-494e-4a53-bf7e-e95da29ce902.png)\n",
     "\n",
-    "Our LangGraph state will be composed of two items:\n",
-    "1. The root of the search tree\n",
-    "2. The user input"
+    "LangGraph 상태는 두 개 요소로 구성됩니다:\n",
+    "1. 탐산 트리의 루트 노듞\n",
+    "2. 사용자 입력\n"
    ]
   },
   {
@@ -261,9 +261,9 @@
    "id": "cdd3111f-b860-471f-8784-1d5e3783910d",
    "metadata": {},
    "source": [
-    "#### The graph state itself\n",
+    "#### 그래프 상태\n",
     "\n",
-    "The main component is the tree, represented by the root node."
+    "주요 구성 요소는 루트 노듞로 표현된 트리입니다.\n"
    ]
   },
   {
@@ -288,14 +288,14 @@
    "id": "2e8ddf25-d040-4e1f-87bd-5837ff105845",
    "metadata": {},
    "source": [
-    "## Define Language Agent\n",
+    "## 언어 에이전트 정의\n",
     "\n",
-    "Our agent will have three primary LLM-powered processes:\n",
-    "1. Reflect: score the action based on the tool response.\n",
-    "2. Initial response: to create the root node and start the search.\n",
-    "3. Expand: generate 5 candidate \"next steps\" from the best spot in the current tree\n",
+    "우리 에이전트는 세 개의 주요 LLM 기반 프로세스를 갖습니다:\n",
+    "1. 반성: 도구 응답을 기반으로 행동을 점수합니다.\n",
+    "2. 최초 응답: 루트 노듞를 생성하고 탐산을 시작합니다.\n",
+    "3. 확장: 현재 트리에서 가장 좋은 지점에서 5개의 다음 행동 호분을 생성합니다.\n",
     "\n",
-    "For more \"Grounded\" tool applications (such as code synthesis), you could integrate code execution into the reflection/reward step. This type of external feedback is very useful (though adds complexity to an already complicated example notebook)."
+    "코드 생성과 같은 더 '궐갔은' 도구 작업을 위해서는 반성/보상 부분에 코드 실행을 포함할 수 있습니다. 이런 외부 피드래치는 매우 유용하지만, 이미 분지된 예제 노트북에 더 큰 분분드록을 삽니다.\n"
    ]
   },
   {
@@ -315,9 +315,9 @@
    "id": "5d460856-e26d-4430-910e-0aac58563612",
    "metadata": {},
    "source": [
-    "#### Tools\n",
+    "#### 도구\n",
     "\n",
-    "For our example, we will give the language agent a search engine."
+    "이 예제에서는 언어 에이전트에게 검색 에어진을 제공합니다.\n"
    ]
   },
   {
@@ -342,10 +342,10 @@
    "id": "1c611f1e-74b4-4157-997c-face8ad409a4",
    "metadata": {},
    "source": [
-    "### Reflection\n",
+    "### 반성\n",
     "\n",
-    "The reflection chain will score agent outputs based on the decision and the tool responses.\n",
-    "We will call this within the other two nodes."
+    "반성 체인은 결정과 도구 응답을 기반으로 에이전트 출력을 평가합니다.\n",
+    "이 과정은 다른 둘 노듞 내부에서 호출합니다.\n"
    ]
   },
   {
@@ -396,9 +396,9 @@
    "id": "4e47dfb2-4ab3-4a31-b117-f07786b357cb",
    "metadata": {},
    "source": [
-    "### Initial Response\n",
+    "### 최초 응답\n",
     "\n",
-    "We start with a single root node, generated by this first step. It responds to the user input either with a tool invocation or a response."
+    "첫 단계에서 생성된 하나의 루트 노듞로 시작합니다. 이 노듞는 사용자 입력에 대해 도구 호출 또는 응답으로 반응합니다.\n"
    ]
   },
   {
@@ -460,9 +460,9 @@
    "id": "7a7d34a6-cee0-4321-989a-963ca4b2caeb",
    "metadata": {},
    "source": [
-    "#### Starting Node\n",
+    "#### 시작 노듞\n",
     "\n",
-    "We will package up the candidate generation and reflection in a single node of our graph. This is represented by the following function:"
+    "후부 생성과 반성 과정을 하나의 그래프 노듞로 묶어 부기니다. 아래 함수가 이를 구현합니다:\n"
    ]
   },
   {
@@ -508,9 +508,9 @@
    "id": "34452e88-e33a-474c-9623-075d1f434dda",
    "metadata": {},
    "source": [
-    "### Candidate Generation\n",
+    "### 호분 생성\n",
     "\n",
-    "The following code prompts the same LLM to generate N additional candidates to check."
+    "다음 코드는 동일한 LLM에게 검토할 추가 호분 N개를 생성하도록 요청합니다.\n"
    ]
   },
   {
@@ -571,10 +571,10 @@
    "id": "88ecf775-29ed-4ebd-8297-d1aa3cda3f9b",
    "metadata": {},
    "source": [
-    "#### Candidate generation node\n",
+    "#### 호분 생성 노듞\n",
     "\n",
-    "We will package the candidate generation and reflection steps in the following \"expand\" node.\n",
-    "We do all the operations as a batch process to speed up execution."
+    "호분 생성과 반성 단계를 다음 \"expand\" 노듞로 묶어서 질화합니다.\n",
+    "모든 작업을 버치 체로 진행하여 직혁 속도를 높입니다.\n"
    ]
   },
   {
@@ -666,9 +666,9 @@
    "id": "84bad5da-645d-4c6a-83dd-8c852f21f622",
    "metadata": {},
    "source": [
-    "## Create Graph\n",
+    "## 그래프 생성\n",
     "\n",
-    "With those two nodes defined, we are ready to define the graph. After each agent step, we have the option of finishing."
+    "이 두 노듞를 정의한 후 그래프를 정의할 준비가 되었습니다. 각 에이전트 단계 후 종료 옵션을 선택할 수 있습니다.\n"
    ]
   },
   {
@@ -744,7 +744,7 @@
    "id": "1383d69c-1d90-43f5-987e-c7fc4c3a24f8",
    "metadata": {},
    "source": [
-    "## Invoke"
+    "## 실행\n"
    ]
   },
   {
@@ -1007,11 +1007,11 @@
    "id": "f1b5140d-f51e-4032-8bc8-d7153252e3bf",
    "metadata": {},
    "source": [
-    "## Conclusion\n",
+    "## 마무리\n",
     "\n",
-    "Congrats on implementing LATS! This is a technique that can be reasonably fast and effective at solving complex reasoning tasks. A few notes that you probably observed above:\n",
-    "1. While effective , the tree rollout can take additional compute time. If you wanted to include this in a production app, you'd either want to ensure that intermediate steps are streamed (so the user sees the thinking process/has access to intermediate results) or use it for fine-tuning data to improve the single-shot accuracy and avoid long rollouts.\n",
-    "2. The candidate selection process is only as good as the reward you generate. Here we are using self-reflection exclusively, but if you have an external source of feedback (such as code test execution), that should be incorporated in the locations mentioned above."
+    "LATS 구현을 축하드립니다! 이 기법은 부분한 반방으로 부분과 효과적으로 버티게 제공할 수 있습니다. 위에서 확인했드림 몇 개 점이 있습니다:\n",
+    "1. 효과적이겠지만, 트리 로반이는 추가 콜차 시간을 요건합니다. 이를 실수 에프에 포함하고 싶다면, 중간 단계가 스트리버뱅습니다(사용자가 생각 과정을 보게 한다거나 중간 결과에 접근할 수 있게 한다) 또는 한 마디 선택할 수 있도록 다운 로우시효과을 발견하고 다시 새로 통정적인 내용을 타이딩 했다.\n",
+    "2. 호분 선택 과정은 생성한 반성 회관의 진정과에 따라 만족도가 다르고해지겠다. 외부 피드래치를 지나치워서 (예를 들면 코드 테스트 시행), 위에서 인생한 위치에 포함되어야 합니다.\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- translate markdown text in `docs/docs/tutorials/lats/lats.ipynb` to Korean
- run `make format-docs`, `make lint-docs`, and `make tests`

## Testing
- `make format-docs`
- `make lint-docs`
- `make tests`


------
https://chatgpt.com/codex/tasks/task_e_688c56acbfb8832780f12e26021e04ef